### PR TITLE
Revert "Personalized stream"

### DIFF
--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -444,9 +444,9 @@ class Streams:
             logo = "https://static-cdn.jtvnw.net/jtv_user_pictures/xarth/404_user_70x70.png"
         status = channel["status"]
         if not status:
-            status = "Untitled broadcast on :twitch_logo:"
+            status = "Untitled broadcast"
         embed = discord.Embed(title=status, url=url)
-        embed.set_author(name=":twitch_logo: - " + channel["display_name"])
+        embed.set_author(name=channel["display_name"])
         embed.add_field(name="Followers", value=channel["followers"])
         embed.add_field(name="Total views", value=channel["views"])
         embed.set_thumbnail(url=logo)
@@ -463,7 +463,7 @@ class Streams:
         channel = livestream["channel"]
         url = channel["channel_link"]
         embed = discord.Embed(title=livestream["media_status"], url=url)
-        embed.set_author(name=":hitbox_logo - " + livestream["media_name"])
+        embed.set_author(name=livestream["media_name"])
         embed.add_field(name="Followers", value=channel["followers"])
         #embed.add_field(name="Views", value=channel["views"])
         embed.set_thumbnail(url=base_url + channel["user_logo"])
@@ -479,7 +479,7 @@ class Streams:
         user = data["user"]
         url = "https://mixer.com/" + data["token"]
         embed = discord.Embed(title=data["name"], url=url)
-        embed.set_author(name=":mixer_logo: - " + user["username"])
+        embed.set_author(name=user["username"])
         embed.add_field(name="Followers", value=data["numFollowers"])
         embed.add_field(name="Total views", value=data["viewersTotal"])
         if user["avatarUrl"]:
@@ -500,7 +500,7 @@ class Streams:
         thumbnail = ("https://thumb.picarto.tv/thumbnail/{}.jpg"
                      "".format(data["name"]))
         embed = discord.Embed(title=data["title"], url=url)
-        embed.set_author(name="picarto_logo: - " + data["name"])
+        embed.set_author(name=data["name"])
         embed.set_image(url=thumbnail + self.rnd_attr())
         embed.add_field(name="Followers", value=data["followers"])
         embed.add_field(name="Total views", value=data["viewers_total"])
@@ -517,7 +517,7 @@ class Streams:
             data["adult"] = ""
 
         embed.color = 0x4C90F3
-        embed.set_footer(text=":underage: - {adult}Category: {category} | Tags: {tags}"
+        embed.set_footer(text="{adult}Category: {category} | Tags: {tags}"
                               "".format(**data))
         return embed
 
@@ -601,10 +601,7 @@ class Streams:
                                 continue
                             mention = self.settings.get(channel.server.id, {}).get("MENTION", "")
                             can_speak = channel.permissions_for(channel.server.me).send_messages
-                            if stream["NAME"] = piano_tv
-                                message = mention + " <@180512508870656000> is live!"
-                            else
-                                message = mention + " {} is live!".format(stream["NAME"])
+                            message = mention + " {} is live!".format(stream["NAME"])
                             if channel and can_speak:
                                 m = await self.bot.send_message(channel, message, embed=embed)
                                 messages_sent.append(m)


### PR DESCRIPTION
Reverts mrfizzl3/Red-DiscordBot#8
```python
[13/12/2017 22:43] ERROR owner load 69: ('invalid syntax', ('C:\\Users\\Administrator\\Desktop\\Kermit\\Red-DiscordBot\\cogs\\streams.py', 604, 47, '                            if stream["NAME"] = piano_tv\n'))
Traceback (most recent call last):
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\owner.py", line 946, in _load_cog
    mod_obj = importlib.import_module(cogname)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python36-32\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 978, in _gcd_import
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\streams.py", line 604
    if stream["NAME"] = piano_tv
                      ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\owner.py", line 65, in load
    self._load_cog(module)
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\owner.py", line 950, in _load_cog
    raise CogLoadError(*e.args)
cogs.owner.CogLoadError: ('invalid syntax', ('C:\\Users\\Administrator\\Desktop\\Kermit\\Red-DiscordBot\\cogs\\streams.py', 604, 47, '                            if stream["NAME"] = piano_tv\n'))
Traceback (most recent call last):
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\owner.py", line 946, in _load_cog
    mod_obj = importlib.import_module(cogname)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python36-32\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 978, in _gcd_import
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\streams.py", line 604
    if stream["NAME"] = piano_tv
                      ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\owner.py", line 65, in load
    self._load_cog(module)
  File "C:\Users\Administrator\Desktop\Kermit\Red-DiscordBot\cogs\owner.py", line 950, in _load_cog
    raise CogLoadError(*e.args)
cogs.owner.CogLoadError: ('invalid syntax', ('C:\\Users\\Administrator\\Desktop\\Kermit\\Red-DiscordBot\\cogs\\streams.py', 604, 47, '                            if stream["NAME"] = piano_tv\n'))```
